### PR TITLE
Fixed typo on the main page.

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -10,7 +10,7 @@ article
     li Webtest Frameworks Overview. From Selenium over Watij to Zombie.js. - 
       a(href: 'http://twitter.com/bassistance' ) Jörn Zaefferer
     li Turn your browser into an Apple Remote with Arduino - 
-      a(href: 'http://http://maik-schmidt.de/' ) Maik Schmidt
+      a(href: 'http://maik-schmidt.de/' ) Maik Schmidt
 
   p Also have a look at the&nbsp;
     a(href: 'http://github.com/luebken/Cologne.js/wiki/Talks') proposed talks


### PR DESCRIPTION
Hi,

The link to the http://maik-schmidt.de/ is broken on the main page. It's targeting to http://http://maik-schmidt.de/

Renat
