### PR TITLE
fixed link to google maps

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -26,7 +26,7 @@ aside.grid-row(role="complementary")
   .grid-1-3
     h3 Come over, bring friends
     p
-      | <a href="http://maps.google.de/maps/place?q=Gasmotorenfabrik,+Deutz-M%C3%BClheimer+Stra%C3%9Fe+129,+51063+K%C3%B6ln">Coworking Cologne</a><br/>
+      | <a href="http://maps.google.de/maps?q=Gasmotorenfabrik,+Deutz-M%C3%BClheimer+Stra%C3%9Fe+129,+51063+K%C3%B6ln">Coworking Cologne</a><br/>
       | Gasmotorenfabrik, 3. Etage <br/>
       | Deutz-Mülheimer Straße 129 <br/>
       | 51063 Köln


### PR DESCRIPTION
old link (not working for me):
https://maps.google.de/maps/place?q=Gasmotorenfabrik,+Deutz-M%C3%BClheimer+Stra%C3%9Fe+129,+51063+K%C3%B6ln

new link:
https://maps.google.de/maps?q=Gasmotorenfabrik,+Deutz-M%C3%BClheimer+Stra%C3%9Fe+129,+51063+K%C3%B6ln
